### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CollAgoraCanvas_v0.8
-(At present) an un-finished electronic workspace for e. g. putting virtual sticker-notes on casnvases like the TBL CC (see  e.g., https://www.sciencedirect.com/science/article/pii/S1877050924014212 )
+(At present) an un-finished electronic workspace for e. g. putting virtual sticker-notes on canvases like the TBL CC (see  e.g., https://www.sciencedirect.com/science/article/pii/S1877050924014212 )
 
 Currently I propose implementing it locally on your machine as a project using e g WebStorm IDE (that will create other needed files) and running it on Chrome.
 


### PR DESCRIPTION
## Summary
- correct a typo in README 'casnvases' -> 'canvases'

## Testing
- `git status --short`